### PR TITLE
refactor: 리듀서 결합을 커스텀 훅으로 분리중

### DIFF
--- a/src/lib/api/blogApi.ts
+++ b/src/lib/api/blogApi.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import Axios from 'Axios';
 
 class BlogApi {
     _REST_API_URL: string;
@@ -8,22 +8,22 @@ class BlogApi {
     };
 
     getAllTags = () => {
-        return axios.get(
+        return Axios.get(
             this._REST_API_URL + "tags"
         );
     };
     getPostList = (type: string) => {
-        return axios.get(
+        return Axios.get(
             `${this._REST_API_URL}${type}`
         );
     };
     getPostContents = (type: string, idx: string) => {
-        return axios.get(
+        return Axios.get(
             `${this._REST_API_URL}${type}?idx=${idx}`
         );
     };
     getTagPostList = (type: string, idx: string) => {
-        return axios.get(
+        return Axios.get(
             `${this._REST_API_URL}taglist?type=${type}&idx=${idx}`
         );
     };

--- a/src/lib/api/blogApi.ts
+++ b/src/lib/api/blogApi.ts
@@ -1,28 +1,28 @@
 import axios from 'axios';
 
 class BlogApi {
-    _REST_API_URL : string;
+    _REST_API_URL: string;
 
     constructor() {
         this._REST_API_URL = "https://isa-myblog.herokuapp.com/post/";
     };
 
-    getAllTags =  () => {
+    getAllTags = () => {
         return axios.get(
             this._REST_API_URL + "tags"
         );
     };
-    getPostList = (type : string) => {
+    getPostList = (type: string) => {
         return axios.get(
             `${this._REST_API_URL}${type}`
         );
     };
-    getPostContents = (type : string, idx : string) => {
+    getPostContents = (type: string, idx: string) => {
         return axios.get(
             `${this._REST_API_URL}${type}?idx=${idx}`
         );
     };
-    getTagPostList = (type : string, idx : string) => {
+    getTagPostList = (type: string, idx: string) => {
         return axios.get(
             `${this._REST_API_URL}taglist?type=${type}&idx=${idx}`
         );

--- a/src/lib/custom/post.ts
+++ b/src/lib/custom/post.ts
@@ -13,8 +13,11 @@ function postList() {
     const getPostList = () => {
         dispatch(Actions.LOADPOSTLIST);
     }
+    const getPostListByTag = (type: string, idx: string) => {
+        dispatch(Actions.LOADPOSTLISTBYTAG(type, idx));
+    }
 
-    return { postList, getPostList };
+    return { postList, getPostList, getPostListByTag };
 }
 function postContents() {
     const { postContents } = useSelector((state: RootState) => ({

--- a/src/lib/custom/post.ts
+++ b/src/lib/custom/post.ts
@@ -1,0 +1,21 @@
+import { useSelector, useDispatch } from 'react-redux';
+
+import { RootState } from '../../store/reducers';
+
+import * as Actions from '../../store/actions';
+
+function postList() {
+    const { postList } = useSelector((state: RootState) => ({
+        postList : state.PostList.PostList
+    }));
+
+    const dispatch = useDispatch();
+    const getPostList = () => {
+        dispatch(Actions.LOADPOSTLIST);
+    }
+    
+    return { postList, getPostList };
+}
+
+
+export { postList }

--- a/src/lib/custom/post.ts
+++ b/src/lib/custom/post.ts
@@ -6,16 +6,28 @@ import * as Actions from '../../store/actions';
 
 function postList() {
     const { postList } = useSelector((state: RootState) => ({
-        postList : state.PostList.PostList
+        postList: state.PostList.PostList
     }));
 
     const dispatch = useDispatch();
     const getPostList = () => {
         dispatch(Actions.LOADPOSTLIST);
     }
-    
+
     return { postList, getPostList };
+}
+function postContents() {
+    const { postContents } = useSelector((state: RootState) => ({
+        postContents: state.PostContents.post
+    }));
+
+    const dispatch = useDispatch();
+    const getPostContents = (type: string, idx: string) => {
+        dispatch(Actions.LOADPOSTCONTENTS(type, idx));
+    }
+
+    return { postContents, getPostContents }
 }
 
 
-export { postList }
+export { postList, postContents }

--- a/src/lib/custom/tags.ts
+++ b/src/lib/custom/tags.ts
@@ -1,20 +1,15 @@
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { RootState } from '../../store/reducers';
 
-import * as Actions from '../../store/actions';
 
 function tagList() {
     const { tagList } = useSelector((state: RootState) => ({
-        tagList : state.TagList.tagList
+        tagList: state.TagList.tagList
     }));
 
-    const dispatch = useDispatch();
-    const getTagList = () => {
-        dispatch(Actions.LOADTAGLIST);
-    }
-    
-    return { tagList, getTagList };
+    return { tagList };
 }
+
 
 export { tagList }


### PR DESCRIPTION
스토어와 컴포넌트 간의 결합도를 낮추고 응집성을 높이기 위해서 기존의 커넥트 방식에서
커스텀훅 방식으로 리팩토링 진행